### PR TITLE
Working with SQL Migrations

### DIFF
--- a/migrations/000001_create_movies_table.down.sql
+++ b/migrations/000001_create_movies_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS movies;

--- a/migrations/000001_create_movies_table.up.sql
+++ b/migrations/000001_create_movies_table.up.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS movies (
+    id bigserial PRIMARY KEY,  
+    created_at timestamp(0) with time zone NOT NULL DEFAULT NOW(),
+    title text NOT NULL,
+    year integer NOT NULL,
+    runtime integer NOT NULL,
+    genres text[] NOT NULL,
+    version integer NOT NULL DEFAULT 1
+)

--- a/migrations/000002_add_movies_check_constraints.down.sql
+++ b/migrations/000002_add_movies_check_constraints.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE movies DROP CONSTRAINT IF EXISTS movies_runtime_check;
+
+ALTER TABLE movies DROP CONSTRAINT IF EXISTS movies_year_check;
+
+ALTER TABLE movies DROP CONSTRAINT IF EXISTS genres_length_check;

--- a/migrations/000002_add_movies_check_constraints.up.sql
+++ b/migrations/000002_add_movies_check_constraints.up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE movies ADD CONSTRAINT movies_runtime_check CHECK (runtime >= 0);
+
+ALTER TABLE movies ADD CONSTRAINT movies_year_check CHECK (year BETWEEN 1888 AND date_part('year', now()));
+
+ALTER TABLE movies ADD CONSTRAINT genres_length_check CHECK (array_length(genres, 1) BETWEEN 1 AND 5);


### PR DESCRIPTION
This pull request introduces changes to create a new `movies` table and add appropriate constraints to ensure data integrity. The most important changes include the creation of the table, the addition of constraints, and the corresponding rollback scripts.

Table creation:

* [`migrations/000001_create_movies_table.up.sql`](diffhunk://#diff-c538f633678e900031b6af811b30b632591f4089777d28ef303fd8b38a4486cbR1-R9): Created the `movies` table with columns `id`, `created_at`, `title`, `year`, `runtime`, `genres`, and `version`.

Table deletion:

* [`migrations/000001_create_movies_table.down.sql`](diffhunk://#diff-4cf411554cf5c8eaa4b63a31d5048867cc277b58f721710557df793345c3f9f9R1): Added a script to drop the `movies` table if it exists.

Adding constraints:

* [`migrations/000002_add_movies_check_constraints.up.sql`](diffhunk://#diff-126abc144e3a4d79bfb8053eb7a0075b8bd2b2ad863c9da46d2fb56aa8e0be51R1-R5): Added constraints to ensure `runtime` is non-negative, `year` is within a valid range, and `genres` array length is between 1 and 5.

Removing constraints:

* [`migrations/000002_add_movies_check_constraints.down.sql`](diffhunk://#diff-82ac77ff36e01a71f451ed073ea3cb2eaf0d8d71c9edcd560e49979b7cf5b049R1-R5): Added a script to drop the constraints on the `movies` table if they exist.