### PR TITLE
Feat/graceful shutdown

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"flag"
-	"fmt"
 	"log/slog"
-	"net/http"
 	"os"
 	"time"
 
@@ -64,12 +62,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	db.SetMaxOpenConns(cfg.db.maxOpenConns)
-
-	db.SetMaxIdleConns(cfg.db.maxIdleConns)
-
-	db.SetConnMaxIdleTime(cfg.db.maxIdleTime)
-
 	defer db.Close()
 
 	logger.Info("database connection pool established")
@@ -80,20 +72,11 @@ func main() {
 		models: data.NewModel(db),
 	}
 
-	srv := &http.Server{
-		Addr:         fmt.Sprintf(":%d", cfg.port),
-		Handler:      app.routes(),
-		IdleTimeout:  time.Minute,
-		ReadTimeout:  5 * time.Second,
-		WriteTimeout: 10 * time.Second,
-		ErrorLog:     slog.NewLogLogger(logger.Handler(), slog.LevelError),
+	err = app.serve()
+	if err != nil {
+		logger.Error(err.Error())
+		os.Exit(1)
 	}
-
-	logger.Info("starting server", "addr", srv.Addr, "env", cfg.env)
-
-	err = srv.ListenAndServe()
-	logger.Error(err.Error())
-	os.Exit(1)
 }
 
 func openDB(cfg config) (*sql.DB, error) {
@@ -101,6 +84,12 @@ func openDB(cfg config) (*sql.DB, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	db.SetMaxOpenConns(cfg.db.maxOpenConns)
+
+	db.SetMaxIdleConns(cfg.db.maxIdleConns)
+
+	db.SetConnMaxIdleTime(cfg.db.maxIdleTime)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -20,19 +22,34 @@ func (app *application) serve() error {
 		ErrorLog:     slog.NewLogLogger(app.logger.Handler(), slog.LevelError),
 	}
 
+	shutdownError := make(chan error)
+
 	go func() {
 		quit := make(chan os.Signal, 1)
-
 		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-
 		s := <-quit
 
-		app.logger.Info("caught signal", "signal", s.String())
+		app.logger.Info("shutting down server", "signal", s.String())
 
-		os.Exit(0)
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		shutdownError <- srv.Shutdown(ctx)
 	}()
 
 	app.logger.Info("starting server", "addr", srv.Addr, "env", app.config.env)
 
-	return srv.ListenAndServe()
+	err := srv.ListenAndServe()
+	if !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+
+	err = <-shutdownError
+	if err != nil {
+		return err
+	}
+
+	app.logger.Info("stopped server", "addr", srv.Addr)
+
+	return nil
 }

--- a/cmd/api/server.go
+++ b/cmd/api/server.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+)
+
+func (app *application) serve() error {
+	srv := &http.Server{
+		Addr:         fmt.Sprintf(":%d", app.config.port),
+		Handler:      app.routes(),
+		IdleTimeout:  time.Minute,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		ErrorLog:     slog.NewLogLogger(app.logger.Handler(), slog.LevelError),
+	}
+
+	go func() {
+		quit := make(chan os.Signal, 1)
+
+		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+
+		s := <-quit
+
+		app.logger.Info("caught signal", "signal", s.String())
+
+		os.Exit(0)
+	}()
+
+	app.logger.Info("starting server", "addr", srv.Addr, "env", app.config.env)
+
+	return srv.ListenAndServe()
+}


### PR DESCRIPTION
This pull request includes significant refactoring and reorganization of the server startup and shutdown logic in the `cmd/api` package. The primary changes involve moving server-related code to a new file and improving the server shutdown process.

### Refactoring and Reorganization:

* [`cmd/api/main.go`](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL67-L72): Removed server setup and configuration code from the `main` function and moved it to a new `serve` method in the `application` struct. [[1]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL67-L72) [[2]](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL83-R93)
* [`cmd/api/main.go`](diffhunk://#diff-ae22ad1e20b89eaefa8e09e4ed89443ac10fdc555b9767625f3866e3853100afL7-L9): Removed unnecessary import statements to clean up the code.

### New Server File:

* [`cmd/api/server.go`](diffhunk://#diff-f0e517910d6e008a39b6409ee16a40c642689b9f9c335a63d39b116e21a8b207R1-R55): Created a new file to handle server setup, configuration, and graceful shutdown logic. This includes setting timeouts, logging, and handling OS signals for shutdown.